### PR TITLE
fix: classic 前端构建失败 & 升级 actions 到 Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build new-api
     steps:
     
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
     
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -42,19 +42,21 @@ jobs:
           CI: ""
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
-          cd new-api/web/default
-          bun install
+          cd new-api/web
+          bun install --frozen-lockfile
+          cd default
           DISABLE_ESLINT_PLUGIN='true' VITE_REACT_APP_VERSION="${{ steps.upstream.outputs.tag }}" bun run build
-          cd ../../..
+          cd ../..
 
       - name: Build Frontend (classic)
         env:
           CI: ""
         run: |
-          cd new-api/web/classic
-          bun install
+          cd new-api/web
+          bun install --filter ./classic --frozen-lockfile
+          cd classic
           VITE_REACT_APP_VERSION="${{ steps.upstream.outputs.tag }}" bun run build
-          cd ../../..
+          cd ../..
 
       - name: Build Backend
         uses: vmactions/freebsd-vm@v1
@@ -75,14 +77,14 @@ jobs:
             go build -ldflags "-s -w -X 'github.com/QuantumNous/new-api/common.Version=${{ steps.upstream.outputs.tag }}' -extldflags '-static'" -o new-api
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: new-api-freebsd
           path: |
               new-api/new-api
   
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## 问题

`Build Frontend (classic)` 步骤构建失败，报错：

```
Package subpath './format/index.js' is not defined by "exports" in .../date-fns/package.json
```

## 根因

在 bun workspace 中，`@douyinfe/semi-ui` 依赖 `date-fns@^2` + `date-fns-tz@^1.3.8`，而 `web/default` 的 `react-day-picker` 引入了 `date-fns@4.4.0` 被提升到 workspace 根。提升到根的 `date-fns-tz@1` 解析到了根的 `date-fns@4`（其严格的 `exports` 字段封锁了 `date-fns-tz` 用到的子路径导入）→ 构建失败。

当前 workflow 用的是 `cd new-api/web/classic && bun install`（无 `--filter`、无 `--frozen-lockfile`），会把整个 workspace 的依赖都装上，触发上述提升冲突。

## 修复

对齐上游 `QuantumNous/new-api` 的 `release.yml` 安装命令：

- 从 `web/`（workspace 根）安装，而不是 member 目录
- 加 `--frozen-lockfile` 尊重提交的 lockfile
- classic 用 `--filter ./classic`，只装 classic 子树的依赖，避免 default 的 `date-fns@4` 被提升，让 `date-fns-tz` 正确解析到 `date-fns@2.30.0`

同时升级三个仍跑在 Node 20 的 action 到 Node 24 兼容主版本，消除 deprecation 警告：

- `actions/checkout@v4` → `@v7`
- `actions/upload-artifact@v4` → `@v7`
- `softprops/action-gh-release@v2` → `@v3`

## 验证

已在 fork 上端到端跑通（run 28765113751），全绿，release 正常发布，无 Node 20 deprecation 警告。

## 备注

bun 不支持嵌套 overrides/resolutions，所以只能通过对齐安装命令来解决，无法用 resolutions 字段绕过。